### PR TITLE
feat: adding json-ld support to resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,38 @@ For a complete example of building a résumé with all available sections, see t
 - Certificates
 - References
 
+## JSON-LD Transformation
+
+Resume PHP provides a method to transform resume data into `JSON-LD` format using the `toJsonLd()` method on the `Resume` object.
+
+JSON-LD (JavaScript Object Notation for Linked Data) is a lightweight format for structuring data that is easily understood by search engines and web services.
+
+### How it works:
+
+The `toJsonLd()` method converts your résumé into a structured array following the `schema.org/Person` specification. It extracts key fields such as:
+- name
+- job title
+- website
+- social profiles
+- skills
+
+and formats them for semantic web consumption.
+
+### Why it’s important:
+
+- **SEO & Discoverability**: JSON-LD enables search engines to better understand and index your résumé, improving visibility in search results.
+- **Interoperability**: Many platforms and tools support JSON-LD, making it easier to share and integrate your resume data.
+- **Standardization**: Using schema.org ensures your résumé follows widely accepted standards for personal data representation.
+
+### Example
+
+```php
+$jsonLd = $resume->toJsonLd($resume);
+echo json_encode($jsonLd, JSON_PRETTY_PRINT);
+```
+
+This will output a structured JSON-LD object ready for embedding in web pages or sharing with compatible services.
+
 ## Job Description Builder
 
 The library also includes a `JobDescriptionBuilder` for creating structured job descriptions following [the in progress JSON Job Description schema](https://jsonresume.org/job-description-schema/).

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ and formats them for semantic web consumption.
 ### Example
 
 ```php
-$jsonLd = $resume->toJsonLd($resume);
+$jsonLd = $resume->toJsonLd();
 echo json_encode($jsonLd, JSON_PRETTY_PRINT);
 ```
 

--- a/src/DataObjects/Resume.php
+++ b/src/DataObjects/Resume.php
@@ -115,24 +115,23 @@ final readonly class Resume implements JsonSerializable
     /**
      * Transform the résumé into a structured array for JSON-LD.
      *
-     * @param Resume $resume
      * @return array<string, mixed>
      */
-    public function toJsonLd(Resume $resume): array
+    public function toJsonLd(): array
     {
         return [
             '@context' => 'https://schema.org',
             '@type' => 'Person',
-            'name' => $resume->basics->name,
-            'url' => $resume->basics->url,
-            'jobTitle' => $resume->basics->label,
+            'name' => $this->basics->name,
+            'url' => $this->basics->url,
+            'jobTitle' => $this->basics->label,
             'sameAs' => array_filter(array_map(
                 static fn($profile): ?string => $profile->url,
-                $resume->basics->profiles,
+                $this->basics->profiles,
             )),
             'knowsAbout' => array_map(
                 static fn($skill): string => $skill->name,
-                $resume->skills,
+                $this->skills,
             ),
         ];
     }

--- a/src/DataObjects/Resume.php
+++ b/src/DataObjects/Resume.php
@@ -6,7 +6,6 @@ namespace JustSteveKing\Resume\DataObjects;
 
 use JsonSerializable;
 use JustSteveKing\Resume\Attributes\Field;
-use JustSteveKing\Resume\Enums\Network;
 use JustSteveKing\Resume\Enums\ResumeSchema;
 
 final readonly class Resume implements JsonSerializable
@@ -128,12 +127,12 @@ final readonly class Resume implements JsonSerializable
             'url' => $resume->basics->url,
             'jobTitle' => $resume->basics->label,
             'sameAs' => array_filter(array_map(
-                static fn($profile) => $profile->url,
-                array_filter($resume->basics->profiles, static fn($profile) => $profile->network instanceof Network),
+                static fn($profile): ?string => $profile->url,
+                $resume->basics->profiles,
             )),
             'knowsAbout' => array_map(
-                static fn($skill) => $skill->name,
-                $resume->skills
+                static fn($skill): string => $skill->name,
+                $resume->skills,
             ),
         ];
     }

--- a/src/DataObjects/Resume.php
+++ b/src/DataObjects/Resume.php
@@ -6,6 +6,7 @@ namespace JustSteveKing\Resume\DataObjects;
 
 use JsonSerializable;
 use JustSteveKing\Resume\Attributes\Field;
+use JustSteveKing\Resume\Enums\Network;
 use JustSteveKing\Resume\Enums\ResumeSchema;
 
 final readonly class Resume implements JsonSerializable
@@ -109,6 +110,31 @@ final readonly class Resume implements JsonSerializable
             'has_volunteer_experience' => ! empty($this->volunteer),
             'has_awards' => ! empty($this->awards),
             'has_publications' => ! empty($this->publications),
+        ];
+    }
+
+    /**
+     * Transform the résumé into a structured array for JSON-LD.
+     *
+     * @param Resume $resume
+     * @return array<string, mixed>
+     */
+    public function toJsonLd(Resume $resume): array
+    {
+        return [
+            '@context' => 'https://schema.org',
+            '@type' => 'Person',
+            'name' => $resume->basics->name,
+            'url' => $resume->basics->url,
+            'jobTitle' => $resume->basics->label,
+            'sameAs' => array_filter(array_map(
+                static fn($profile) => $profile->url,
+                array_filter($resume->basics->profiles, static fn($profile) => $profile->network instanceof Network),
+            )),
+            'knowsAbout' => array_map(
+                static fn($skill) => $skill->name,
+                $resume->skills
+            ),
         ];
     }
 }

--- a/tests/DataObjects/ResumeTest.php
+++ b/tests/DataObjects/ResumeTest.php
@@ -46,7 +46,7 @@ final class ResumeTest extends PackageTestCase
             schema: ResumeSchema::V1,
         );
 
-        $result = $resume->toJsonLd($resume);
+        $result = $resume->toJsonLd();
 
         $this->assertIsArray($result);
         $this->assertSame('https://schema.org', $result['@context']);
@@ -77,7 +77,7 @@ final class ResumeTest extends PackageTestCase
             schema: ResumeSchema::V1,
         );
 
-        $result = $resume->toJsonLd($resume);
+        $result = $resume->toJsonLd();
 
         $this->assertEmpty($result['sameAs']);
         $this->assertEmpty($result['knowsAbout']);

--- a/tests/DataObjects/ResumeTest.php
+++ b/tests/DataObjects/ResumeTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DataObjects;
+
+use JustSteveKing\Resume\DataObjects\Basics;
+use JustSteveKing\Resume\DataObjects\Profile;
+use JustSteveKing\Resume\DataObjects\Resume;
+use JustSteveKing\Resume\DataObjects\Skill;
+use JustSteveKing\Resume\Enums\Network;
+use JustSteveKing\Resume\Enums\ResumeSchema;
+use Tests\PackageTestCase;
+
+final class ResumeTest extends PackageTestCase
+{
+    public function testTransformReturnsCorrectJsonLdStructure(): void
+    {
+        $basics = new Basics(
+            name: 'Jane Doe',
+            label: 'Software Engineer',
+            email: 'jane@example.com',
+            url: 'https://janedoe.dev',
+            profiles: [
+                new Profile(
+                    network: Network::GitHub,
+                    username: 'JaneDoe',
+                    url: 'https://github.com/JaneDoe'
+                ),
+                new Profile(
+                    network: Network::Twitter,
+                    username: 'JaneDoe',
+                    url: 'https://twitter.com/JaneDoe'
+                ),
+            ],
+        );
+
+        $skills = [
+            new Skill(name: 'PHP'),
+            new Skill(name: 'JavaScript'),
+        ];
+
+        $resume = new Resume(
+            basics: $basics,
+            skills: $skills,
+            schema: ResumeSchema::V1
+        );
+
+        $result = $resume->toJsonLd($resume);
+
+        $this->assertIsArray($result);
+        $this->assertSame('https://schema.org', $result['@context']);
+        $this->assertSame('Person', $result['@type']);
+        $this->assertSame('Jane Doe', $result['name']);
+        $this->assertSame('https://janedoe.dev', $result['url']);
+        $this->assertSame('Software Engineer', $result['jobTitle']);
+        $this->assertEquals([
+            'https://github.com/JaneDoe',
+            'https://twitter.com/JaneDoe',
+        ], $result['sameAs']);
+        $this->assertEquals(['PHP', 'JavaScript'], $result['knowsAbout']);
+    }
+
+    public function testTransformHandlesMissingProfilesAndSkills(): void
+    {
+        $basics = new Basics(
+            name: 'John Smith',
+            label: 'Developer',
+            email: 'john@example.com',
+            url: 'https://johnsmith.dev',
+            profiles: []
+        );
+
+        $resume = new Resume(
+            basics: $basics,
+            skills: [],
+            schema: ResumeSchema::V1
+        );
+
+        $result = $resume->toJsonLd($resume);
+
+        $this->assertEmpty($result['sameAs']);
+        $this->assertEmpty($result['knowsAbout']);
+    }
+}

--- a/tests/DataObjects/ResumeTest.php
+++ b/tests/DataObjects/ResumeTest.php
@@ -25,12 +25,12 @@ final class ResumeTest extends PackageTestCase
                 new Profile(
                     network: Network::GitHub,
                     username: 'JaneDoe',
-                    url: 'https://github.com/JaneDoe'
+                    url: 'https://github.com/JaneDoe',
                 ),
                 new Profile(
                     network: Network::Twitter,
                     username: 'JaneDoe',
-                    url: 'https://twitter.com/JaneDoe'
+                    url: 'https://twitter.com/JaneDoe',
                 ),
             ],
         );
@@ -43,7 +43,7 @@ final class ResumeTest extends PackageTestCase
         $resume = new Resume(
             basics: $basics,
             skills: $skills,
-            schema: ResumeSchema::V1
+            schema: ResumeSchema::V1,
         );
 
         $result = $resume->toJsonLd($resume);
@@ -68,13 +68,13 @@ final class ResumeTest extends PackageTestCase
             label: 'Developer',
             email: 'john@example.com',
             url: 'https://johnsmith.dev',
-            profiles: []
+            profiles: [],
         );
 
         $resume = new Resume(
             basics: $basics,
             skills: [],
-            schema: ResumeSchema::V1
+            schema: ResumeSchema::V1,
         );
 
         $result = $resume->toJsonLd($resume);


### PR DESCRIPTION
This pull request introduces a new feature for transforming résumé data into the JSON-LD format, along with the necessary documentation, implementation, and tests. The changes enhance the library's capabilities by adding support for structured data representation, improving interoperability and SEO for résumés.

### New Feature: JSON-LD Transformation

* **Documentation Update**: Added a new section in `README.md` to explain the purpose, benefits, and usage of the `toJsonLd()` method, including an example of how to generate JSON-LD from a résumé.
* **Implementation**: Introduced the `toJsonLd()` method in the `Resume` class to transform résumé data into a structured array following the `schema.org/Person` specification. This includes extracting fields like name, job title, social profiles, and skills.
* **Dependency Update**: Added a reference to the `Network` enum in the `Resume` class to support filtering and processing social profiles.

### Testing Enhancements

* **Unit Tests**: Added comprehensive tests in `ResumeTest.php` to verify the correctness of the JSON-LD transformation. Tests cover scenarios with complete data and edge cases with missing profiles or skills.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to convert résumé data into JSON-LD format compliant with schema.org/Person, enabling structured data export for improved SEO and interoperability.

* **Documentation**
  * Updated the README with a new section explaining how to generate and use JSON-LD from résumé data, including usage examples.

* **Tests**
  * Introduced tests to verify correct JSON-LD output and handling of missing profile or skill information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->